### PR TITLE
SMPC joystick peripheral handling

### DIFF
--- a/SMPC.sv
+++ b/SMPC.sv
@@ -583,8 +583,12 @@ module SMPC (
 									0: begin
 										CURRPAD_TYPE <= JOY1_TYPE;
 										CURRPAD_BUTTONS <= JOY1;
-										CURRPAD_ANALOGX1 <= JOY1_X1;
-										CURRPAD_ANALOGY1 <= JOY1_Y1;
+										// MiSTer gives signed with 0,0 at center.
+										// Saturn uses unsigned with 0,0 at top-left.
+										CURRPAD_ANALOGX1 <= {~JOY1_X1[7], JOY1_X1[6:0]};
+										CURRPAD_ANALOGY1 <= {~JOY1_Y1[7], JOY1_Y1[6:0]};
+										CURRPAD_ANALOGX2 <= {~JOY1_X2[7], JOY1_X2[6:0]};
+										CURRPAD_ANALOGY2 <= {~JOY1_Y2[7], JOY1_Y2[6:0]};
 
 										case (JOY1_TYPE)
 											PAD_OFF: begin

--- a/SMPC.sv
+++ b/SMPC.sv
@@ -31,10 +31,16 @@ module SMPC (
 	
 	input      [15:0] JOY1,
 	input      [15:0] JOY2,
-    input       [7:0] JOY1_X,
-    input       [7:0] JOY1_Y,
-    input       [7:0] JOY2_X,
-    input       [7:0] JOY2_Y,
+
+    input       [7:0] JOY1_X1,
+    input       [7:0] JOY1_Y1,
+    input       [7:0] JOY1_X2,
+    input       [7:0] JOY1_Y2,
+    input       [7:0] JOY2_X1,
+    input       [7:0] JOY2_Y1,
+    input       [7:0] JOY2_X2,
+    input       [7:0] JOY2_Y2,
+
 	input       [2:0] JOY1_TYPE,
 	input       [2:0] JOY2_TYPE
 );
@@ -185,9 +191,9 @@ module SMPC (
 
 		PADSTATE_ANALOG_BUTTONSMSB,
 		PADSTATE_ANALOG_BUTTONSLSB,
-		PADSTATE_ANALOG_X,
-		PADSTATE_ANALOG_Y,
-		PADSTATE_ANALOG_Z,
+		PADSTATE_ANALOG_AXIS0,
+		PADSTATE_ANALOG_AXIS1,
+		PADSTATE_ANALOG_AXIS2,
 
 		PADSTATE_IDLE
 	} PadState_t;
@@ -215,8 +221,10 @@ module SMPC (
 		bit [1:0]  CURRPAD_ID;
 		bit [1:0]  CURRPAD_TYPE;
 		bit [15:0] CURRPAD_BUTTONS;
-		bit [7:0]  CURRPAD_ANALOGX;
-		bit [7:0]  CURRPAD_ANALOGY;
+		bit [7:0]  CURRPAD_ANALOGX1;
+		bit [7:0]  CURRPAD_ANALOGY1;
+		bit [7:0]  CURRPAD_ANALOGX2;
+		bit [7:0]  CURRPAD_ANALOGY2;
 		
 		if (!RST_N) begin
 			COMREG <= '0;
@@ -575,8 +583,8 @@ module SMPC (
 									0: begin
 										CURRPAD_TYPE <= JOY1_TYPE;
 										CURRPAD_BUTTONS <= JOY1;
-										CURRPAD_ANALOGX <= JOY1_X;
-										CURRPAD_ANALOGY <= JOY1_Y;
+										CURRPAD_ANALOGX1 <= JOY1_X1;
+										CURRPAD_ANALOGY1 <= JOY1_Y1;
 
 										case (JOY1_TYPE)
 											PAD_OFF: begin
@@ -595,8 +603,8 @@ module SMPC (
 									1: begin
 										CURRPAD_TYPE <= JOY2_TYPE;
 										CURRPAD_BUTTONS <= JOY2;
-										CURRPAD_ANALOGX <= JOY2_X;
-										CURRPAD_ANALOGY <= JOY2_Y;
+										CURRPAD_ANALOGX1 <= JOY2_X1;
+										CURRPAD_ANALOGY1 <= JOY2_Y1;
 
 										case (JOY2_TYPE)
 											PAD_OFF: begin
@@ -665,17 +673,17 @@ module SMPC (
 							end
 							PADSTATE_ANALOG_BUTTONSLSB: begin
 								OREG_RAM_D <= CURRPAD_BUTTONS[7:0];
-								PADSTATE <= PADSTATE_ANALOG_X;
+								PADSTATE <= PADSTATE_ANALOG_AXIS0;
 							end
-							PADSTATE_ANALOG_X: begin
-								OREG_RAM_D <= CURRPAD_ANALOGX;
-								PADSTATE <= PADSTATE_ANALOG_Y;
+							PADSTATE_ANALOG_AXIS0: begin
+								OREG_RAM_D <= CURRPAD_ANALOGX1;
+								PADSTATE <= PADSTATE_ANALOG_AXIS1;
 							end
-							PADSTATE_ANALOG_Y: begin
-								OREG_RAM_D <= CURRPAD_ANALOGY;
-								PADSTATE <= PADSTATE_ANALOG_Z;
+							PADSTATE_ANALOG_AXIS1: begin
+								OREG_RAM_D <= CURRPAD_ANALOGY1;
+								PADSTATE <= PADSTATE_ANALOG_AXIS2;
 							end
-							PADSTATE_ANALOG_Z: begin
+							PADSTATE_ANALOG_AXIS2: begin
 								OREG_RAM_D <= 0; // TODO: shoulder triggers available?
 
 								// done with this peripheral

--- a/Saturn.sv
+++ b/Saturn.sv
@@ -106,7 +106,8 @@ module Saturn (
 	
 	input      [15:0] JOY1,
 	input      [15:0] JOY2,
-	input             JOY2_EN,
+	input       [2:0] JOY1_TYPE,
+	input       [2:0] JOY2_TYPE,
 	
 	input       [6:0] SCRN_EN,
 	input       [2:0] SND_EN,
@@ -661,7 +662,8 @@ module Saturn (
 		
 		.JOY1(JOY1),
 		.JOY2(JOY2),
-		.JOY2_EN(JOY2_EN)
+		.JOY1_TYPE(JOY1_TYPE),
+		.JOY2_TYPE(JOY2_TYPE)
 	);
 	
 	VDP1 VDP1

--- a/Saturn.sv
+++ b/Saturn.sv
@@ -106,6 +106,10 @@ module Saturn (
 	
 	input      [15:0] JOY1,
 	input      [15:0] JOY2,
+	input       [7:0] JOY1_X,
+	input       [7:0] JOY1_Y,
+	input       [7:0] JOY2_X,
+	input       [7:0] JOY2_Y,
 	input       [2:0] JOY1_TYPE,
 	input       [2:0] JOY2_TYPE,
 	
@@ -662,6 +666,12 @@ module Saturn (
 		
 		.JOY1(JOY1),
 		.JOY2(JOY2),
+
+		.JOY1_X(joy0_x),
+		.JOY1_Y(joy0_y),
+		.JOY2_X(joy1_x),
+		.JOY2_Y(joy1_y),
+
 		.JOY1_TYPE(JOY1_TYPE),
 		.JOY2_TYPE(JOY2_TYPE)
 	);

--- a/Saturn.sv
+++ b/Saturn.sv
@@ -106,10 +106,14 @@ module Saturn (
 	
 	input      [15:0] JOY1,
 	input      [15:0] JOY2,
-	input       [7:0] JOY1_X,
-	input       [7:0] JOY1_Y,
-	input       [7:0] JOY2_X,
-	input       [7:0] JOY2_Y,
+	input       [7:0] JOY1_X1,
+	input       [7:0] JOY1_Y1,
+	input       [7:0] JOY1_X2,
+	input       [7:0] JOY1_Y2,
+	input       [7:0] JOY2_X1,
+	input       [7:0] JOY2_Y1,
+	input       [7:0] JOY2_X2,
+	input       [7:0] JOY2_Y2,
 	input       [2:0] JOY1_TYPE,
 	input       [2:0] JOY2_TYPE,
 	
@@ -667,10 +671,14 @@ module Saturn (
 		.JOY1(JOY1),
 		.JOY2(JOY2),
 
-		.JOY1_X(joy0_x),
-		.JOY1_Y(joy0_y),
-		.JOY2_X(joy1_x),
-		.JOY2_Y(joy1_y),
+		.JOY1_X1(JOY1_X1),
+		.JOY1_Y1(JOY1_Y1),
+		.JOY1_X2(JOY1_X2),
+		.JOY1_Y2(JOY1_Y2),
+		.JOY2_X1(JOY2_X1),
+		.JOY2_Y1(JOY2_Y1),
+		.JOY2_X2(JOY2_X2),
+		.JOY2_Y2(JOY2_Y2),
 
 		.JOY1_TYPE(JOY1_TYPE),
 		.JOY2_TYPE(JOY2_TYPE)


### PR DESCRIPTION
<!-- SPDX-License-Identifier: CC0-1.0 -->
<!-- SPDX-FileType: TEXT -->
<!-- SPDX-FileCopyrightText: (c) 2021-2022, The Raetro authors and contributors -->

<!-- Thank you for your contribution! Please replace {Please write here} with your description -->

## What does this do / why do we need it?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

This change adds SMPC peripheral handling for the Arcade Racer wheel controller, the Mission Stick (single and dual configurations), and the Saturn 3D Pad.

## Type of change

<!--
Please delete options that are not relevant.
-->

- [x] New feature (non-breaking change which adds functionality)

## What should a reviewer look out for in this PR?

<!--
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration
-->

Pad SMPC data and OREG values were checked in the SmpcTest_1 and sdm_repack_2 ROMs, and was consistent with the pads' behavior in Mednafen. I also spot-checked the behavior of each pad using a compatible game. For example, SmpcTest_1 displays the Dual Mission Stick as an invalid input, but the dual stick seemed to work fine in Panzer Dragoon II Zwei.

## Additional Comments (if any)

This PR only implements SMPC handling for these peripherals, so anything using SH-2 Direct for anything except the gamepad still won't work yet.

For now, only joysticks are supported - no mouse, keyboard, etc.

Analog triggers are not yet available in the framework, so those are just set to 0 for now. Ideally, the framework will be changed so that analog trigger data is also passed through hps_io and made available to the core.
